### PR TITLE
fix: GitHub OAuth state 파라미터 및 FRONTEND_URL 설정 개선

### DIFF
--- a/.idea/haifu-backend.iml
+++ b/.idea/haifu-backend.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.10 (fastApiProject)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -15,22 +15,25 @@ router = APIRouter(prefix="/api/auth", tags=["Authentication"])
 
 
 @router.get("/github/login", response_model=GitHubLoginUrlResponse)
-async def github_login(origin: str = Query(default="http://localhost:3000")):
+async def github_login(origin: str | None = Query(default=None)):
     """
     GitHub OAuth 로그인 URL 반환
 
     프론트엔드에서 이 URL로 리디렉션하여 사용자를 GitHub 로그인 페이지로 보냄
     """
     # origin 검증
-    if origin not in settings.ALLOWED_FRONTEND_URLS:
-        origin = settings.FRONTEND_URL
+    if origin and origin in settings.ALLOWED_FRONTEND_URLS:
+        state = origin
+    else:
+        # 기본은 항상 설정에서 가져온 FRONTEND_URL
+        state = settings.FRONTEND_URL
     
     github_auth_url = (
         f"https://github.com/login/oauth/authorize"
         f"?client_id={settings.GITHUB_CLIENT_ID}"
         f"&redirect_uri=https://b2s3zdwgbpxjbkbyhfzi4tolqq0igzuo.lambda-url.ap-northeast-2.on.aws/api/auth/github/callback"
         f"&scope=repo,user:email"
-        f"&state={origin}"
+        f"&state={state}"
     )
 
     return GitHubLoginUrlResponse(url=github_auth_url)
@@ -39,7 +42,7 @@ async def github_login(origin: str = Query(default="http://localhost:3000")):
 @router.get("/github/callback")  # response_model 제거
 async def github_callback(
     code: str = Query(description="Github OAuth authorization code"),
-    state: str = Query(default="http://localhost:3000")
+    state: str | None = Query(default=None)
 ):
     """
     GitHub OAuth 콜백 처리
@@ -74,7 +77,11 @@ async def github_callback(
             )
 
         # state에서 프론트엔드 URL 검증
-        frontend_url = state if state in settings.ALLOWED_FRONTEND_URLS else settings.FRONTEND_URL
+        # frontend_url = state if state in settings.ALLOWED_FRONTEND_URLS else settings.FRONTEND_URL
+        if state and state in settings.ALLOWED_FRONTEND_URLS:
+            frontend_url = state
+        else:
+            frontend_url = settings.FRONTEND_URL
         
         if token_response.status_code != 200:
             # 에러 시에도 프론트엔드로 리다이렉트 (에러 메시지 포함)


### PR DESCRIPTION
#12 

GitHub OAuth 로그인 시 state 파라미터와 FRONTEND_URL 설정이 의도대로 동작하지 않던 문제를 해결했습니다.

###  변경사항
1. `/api/auth/github/login` 엔드포인트
	- `origin` 쿼리 파라미터 기본값을 `http://localhost:3000`에서 `None`으로 변경했습니다.
	- `origin`이 없거나 `ALLOWED_FRONTEND_URLS`에 포함되지 않은 경우 `settings.FRONTEND_URL`을 사용하도록 수정했습니다.
	- 최종적으로 state에는 위에서 결정한 값만 들어가도록 하여, 배포 환경에서 SSM으로 설정한 `FRONTEND_URL`이 반영되도록 했습니다.

2. `/api/auth/github/callback` 엔드포인트
	- state의 기본값을 더 이상 `http://localhost:3000`으로 두지 않고 None으로 변경했습니다.
	- state가 존재하고 `ALLOWED_FRONTEND_URLS`에 포함될 때만 해당 값을 `frontend_url`로 사용하고, 그렇지 않은 경우 `settings.FRONTEND_URL`로 안전하게 폴백하도록 수정했습니다.
	- 성공/실패 모두 동일한 로직으로 `frontend_url`을 결정해 리다이렉트 URL의 일관성을 보장합니다.