### PR TITLE
fix: state가 항상 localhost:3000으로 유지되는 문제 수정

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,4 +1,6 @@
 # app/routers/auth.py
+from email.policy import default
+
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import RedirectResponse
 from app.core.config import settings
@@ -10,10 +12,11 @@ router = APIRouter(prefix="/api/auth", tags=["Authentication"])
 
 
 @router.get("/github/login", response_model=ApiResponse[GitHubLoginUrl], responses=common_responses)
-async def github_login(origin: str = Query(default="http://localhost:3000")):
+async def github_login(origin: str = Query(default=None)):
     """
     GitHub OAuth 로그인 URL 반환
     """
+    origin = origin if origin in settings.ALLOWED_FRONTEND_URLS else settings.FRONTEND_URL
     github_auth_url = AuthService.generate_github_auth_url(origin)
     
     return success_response(
@@ -31,7 +34,7 @@ async def github_login(origin: str = Query(default="http://localhost:3000")):
 )
 async def github_callback(
     code: str = Query(description="Github OAuth authorization code"),
-    state: str = Query(default="http://localhost:3000")
+    state: str | None = Query(default=None)
 ):
     """
     GitHub OAuth 콜백 처리


### PR DESCRIPTION
#12 

GitHub OAuth 로그인 요청 시 state 파라미터가 항상 `http://localhost:3000`으로 고정되어,
배포 환경에서도 인증 완료 후 로컬 환경으로 리다이렉트되는 문제가 있었습니다.

이 PR에서는 state가 환경 설정(`FRONTEND_URL`) 또는 프론트에서 전달한 유효한 `origin` 값에 따라 동적으로 설정되도록 수정했습니다.

### 변경 사항
1. `/github/login`
   * `origin` 기본값을 `None`으로 변경하여, 쿼리 파라미터가 없을 경우 기본값으로 `FRONTEND_URL`을 사용하도록 수정
   * `origin`이 `ALLOWED_FRONTEND_URLS`에 포함되지 않은 경우에도 안전하게 `FRONTEND_URL`로 폴백하도록 변경
   * `AuthService.generate_github_auth_url(origin)` 메서드 사용으로 URL 생성 로직을 모듈화
2. `/github/callback`
   * GitHub에서 전달된 `state` 값이 유효한 경우에만 `frontend_url`로 사용, 그렇지 않으면 `settings.FRONTEND_URL`로 폴백
   * 성공 및 실패 리다이렉트 시 동일한 로직으로 일관된 URL 처리