### PR TITLE
fix : redirect url 수정 및 리펙토링

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -49,7 +49,8 @@ def get_settings() -> Settings:
                 response = ssm.get_parameter(Name=name, WithDecryption=True)
                 return response['Parameter']['Value']
             except Exception as e:
-                print(f"다음 파라미터를 가져오는데 실패했습니다: {name}: {e}")
+                import logging
+                logging.getLogger(__name__).error(f"Failed to get parameter {name}: {e}")
                 return ""
 
 
@@ -65,7 +66,8 @@ def get_settings() -> Settings:
             ]
         )
     except Exception as e:
-        print(f"파라미터 스토어를 로드하는데 실패 했습니다.: {e}")
+        import logging
+        logging.getLogger(__name__).error(f"Failed to load parameter store: {e}")
         return Settings()
 
 settings = get_settings()

--- a/app/core/environment.py
+++ b/app/core/environment.py
@@ -1,0 +1,38 @@
+# app/core/environment.py
+import os
+from app.core.config import settings
+
+
+class Environment:
+    """환경 감지 및 관리 유틸리티"""
+    
+    @staticmethod
+    def is_lambda() -> bool:
+        """Lambda 환경인지 확인"""
+        return (
+            os.getenv("AWS_LAMBDA_FUNCTION_NAME") is not None or
+            os.getenv("AWS_EXECUTION_ENV") is not None or
+            os.getenv("LAMBDA_RUNTIME_DIR") is not None or
+            "lambda" in os.getenv("AWS_EXECUTION_ENV", "").lower()
+        )
+    
+    @staticmethod
+    def is_local() -> bool:
+        """로컬 개발 환경인지 확인"""
+        return (
+            settings.ENVIRONMENT == "local" or
+            not Environment.is_lambda()
+        )
+    
+    @staticmethod
+    def get_backend_url() -> str:
+        """현재 환경에 맞는 백엔드 URL 반환"""
+        if Environment.is_lambda():
+            return "https://b2s3zdwgbpxjbkbyhfzi4tolqq0igzuo.lambda-url.ap-northeast-2.on.aws"
+        else:
+            return "http://localhost:8001"
+    
+    @staticmethod
+    def get_environment_name() -> str:
+        """현재 환경 이름 반환"""
+        return "lambda" if Environment.is_lambda() else "local"

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -1,0 +1,35 @@
+# app/core/logging.py
+import logging
+import sys
+from app.core.environment import Environment
+
+
+def setup_logging():
+    """로깅 설정"""
+    # 로그 레벨 설정 (환경에 따라)
+    log_level = logging.DEBUG if Environment.is_local() else logging.INFO
+    
+    # 로그 포맷 설정
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+    
+    # 핸들러 설정
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+    
+    # 루트 로거 설정
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+    root_logger.addHandler(handler)
+    
+    return root_logger
+
+
+def get_logger(name: str) -> logging.Logger:
+    """모듈별 로거 반환"""
+    return logging.getLogger(name)
+
+
+# 앱 시작 시 로깅 설정
+setup_logging()

--- a/app/database.py
+++ b/app/database.py
@@ -2,6 +2,9 @@ import boto3
 from boto3.dynamodb.conditions import Key, Attr
 from typing import Dict, List, Any, Optional
 from app.core.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def get_dynamodb_resource():
@@ -12,7 +15,7 @@ def get_dynamodb_resource():
     """
     if settings.DYNAMODB_ENDPOINT:
         # 로컬 환경: DynamoDB Local 사용
-        print(f"🔧 Using DynamoDB Local at {settings.DYNAMODB_ENDPOINT}")
+        logger.info(f"Using DynamoDB Local at {settings.DYNAMODB_ENDPOINT}")
         return boto3.resource(
             'dynamodb',
             endpoint_url=settings.DYNAMODB_ENDPOINT,
@@ -22,7 +25,7 @@ def get_dynamodb_resource():
         )
     else:
         # 프로덕션 환경: 실제 AWS DynamoDB
-        print(f"☁️  Using AWS DynamoDB in region {settings.AWS_REGION}")
+        logger.info(f"Using AWS DynamoDB in region {settings.AWS_REGION}")
         return boto3.resource(
             'dynamodb',
             region_name=settings.AWS_REGION

--- a/app/main.py
+++ b/app/main.py
@@ -1,28 +1,23 @@
 # app/main.py
-import os
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from mangum import Mangum
 from app.core.config import settings
+from app.core.environment import Environment
+from app.core.logging import get_logger
 from app.routers import auth, repos, health, projects, services
 from app.core.exceptions import http_exception_handler, general_exception_handler
 from app.schemas.common import success_response, ApiResponse, ServerInfo, common_responses
 
-# localhost에서만 Swagger 활성화 여부 판단
-def is_localhost() -> bool:
-    """로컬 환경인지 확인"""
-    return (
-        settings.ENVIRONMENT == "local" or 
-        os.getenv("AWS_LAMBDA_FUNCTION_NAME") is None
-    )
+logger = get_logger(__name__)
 
 # FastAPI 앱 생성
 app = FastAPI(
     title=settings.APP_NAME,
     description="GitHub-based deployment automation service",
     version="1.0.0",
-    docs_url="/docs" if is_localhost() else None,
-    redoc_url="/redoc" if is_localhost() else None,
+    docs_url="/docs" if Environment.is_local() else None,
+    redoc_url="/redoc" if Environment.is_local() else None,
 )
 
 # CORS 설정

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,9 +1,11 @@
 # app/routers/auth.py
 from email.policy import default
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import RedirectResponse
 from app.core.config import settings
+from app.core.environment import Environment
 from app.core.security import get_current_user
 from app.service.auth_service import AuthService
 from app.schemas.common import success_response, ApiResponse, GitHubLoginUrl, UserInfo, common_responses
@@ -34,7 +36,7 @@ async def github_login(origin: str = Query(default=None)):
 )
 async def github_callback(
     code: str = Query(description="Github OAuth authorization code"),
-    state: str | None = Query(default=None)
+    state: Optional[str] = Query(default=None)
 ):
     """
     GitHub OAuth 콜백 처리
@@ -127,9 +129,8 @@ async def generate_test_token(
     Returns:
         JWT 토큰과 사용자 정보
     """
-    import os
     # 프로덕션 환경에서는 접근 불가
-    if os.getenv("AWS_LAMBDA_FUNCTION_NAME") is not None and settings.ENVIRONMENT != "local":
+    if not Environment.is_local():
         from fastapi import HTTPException
         raise HTTPException(
             status_code=403,

--- a/app/service/github_service.py
+++ b/app/service/github_service.py
@@ -3,6 +3,9 @@ import httpx
 import base64
 from typing import Optional, List, Dict, Any
 from app.core.exceptions import GitHubAPIException, AuthenticationException
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
 
 class GitHubService:
     """GitHub API 관련 비즈니스 로직"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,43 +1,29 @@
-annotated-doc==0.0.3
-annotated-types==0.7.0
-anyio==4.11.0
-bcrypt==4.0.1
-boto3==1.40.73
-botocore==1.40.73
-certifi==2025.11.12
-cffi==2.0.0
-click==8.3.0
-cryptography==46.0.3
-ecdsa==0.19.1
-exceptiongroup==1.3.0
-fastapi==0.121.1
-h11==0.16.0
-httpcore==1.0.9
-httptools==0.7.1
+# FastAPI 및 웹 프레임워크
+fastapi==0.115.14
+uvicorn==0.34.3
+starlette==0.46.2
+
+# HTTP 클라이언트
 httpx==0.28.1
-idna==3.11
-jmespath==1.0.1
+httpcore==1.0.9
+
+# AWS 및 클라우드
+boto3==1.40.74
+botocore==1.40.74
 mangum==0.19.0
-passlib==1.7.4
-pyasn1==0.6.1
-pycparser==2.23
-pydantic==2.12.4
-pydantic_core==2.41.5
-PyMySQL==1.1.2
-python-dateutil==2.9.0.post0
-python-dotenv==1.2.1
+
+# 인증 및 보안
 python-jose==3.5.0
-PyYAML==6.0.3
-rsa==4.9.1
-s3transfer==0.14.0
-six==1.17.0
-sniffio==1.3.1
-SQLAlchemy==2.0.44
-starlette==0.49.3
-typing-inspection==0.4.2
-typing_extensions==4.15.0
-urllib3==2.5.0
-uvicorn==0.38.0
-uvloop==0.22.1
-watchfiles==1.1.1
-websockets==15.0.1
+passlib==1.7.4
+bcrypt==5.0.0
+cryptography==46.0.3
+
+# 데이터 검증 및 설정
+pydantic==2.11.7
+pydantic_core==2.33.2
+python-dotenv==1.0.0
+
+# 기타 유틸리티
+python-dateutil==2.9.0.post0
+requests==2.31.0
+typing_extensions==4.14.0


### PR DESCRIPTION
# [ haifu-server 조치 사항 공유 ]

## 1. Production 환경에서도 localhost로 redirect되는 문제 해결

원인 : 환경이 Local인지, Production인지 구분하기 위해서는 프로파일을 적용해야하는데, 현재는 프로파일을 제공하고 있지 않으므로 정상 작동하지 않았습니다. 

해결 방법 : Lambda 서버 환경인지를 기준으로 Production 환경을 구분하는 로직을 environment.py 라는 이름의 Utility로 생성 후, 각 Service 단에서 호출하여 사용하도록 구조 수정하였습니다. 

## 2. Log 사용 시, print 대신 Logging 라이브러리를 사용하도록 수정
(requirements.txt 갱신 완료)

이유 : print는 단순 문자열 출력이라 시간, 로그 레벨(INFO, ERROR 등) 같은 메타데이터가 없습니다. 

FastAPI(Uvicorn)는 async 기반이라 비동기 이벤트 루프에서 동기 I/O인 print를 호출하면 비동기 루프가 잠시 멈추는 치명적인 문제가 있습니다. 

또한, ECS/Fargate 배포 시, 컨테이너 환경에서는 stdout 기반인 print를 남발하게 되면 로그 파이프라인 과부하로 인해 지연되므로 프로덕션 환경에는 logging 라이브러리를 사용하는 것이 적합합니다. 

## 3. Local 테스트를 위한 .env 파일을 분리